### PR TITLE
fix(ui): correct trailing comma and whitespace in general tab

### DIFF
--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -53,14 +53,14 @@ export class GeneralTab extends Tab {
     if (!lintOnActiveFileChangeSetting.getBoolean()) {
       displayLintOnActiveFileChangeSetting.hide();
     }
-    
+
     tempDiv = this.contentEl.createDiv();
     const suppressMessageWhenNoChangeSetting = new ToggleSetting(
       tempDiv,
       'tabs.general.suppress-message-when-no-change.name' as any,
       'tabs.general.suppress-message-when-no-change.description' as any,
       'suppressMessageWhenNoChange',
-      this.plugin
+      this.plugin,
     );
     this.addSettingSearchInfoForGeneralSettings(suppressMessageWhenNoChangeSetting);
 


### PR DESCRIPTION
Adjust the constructor call and remove stray whitespace in the general
tab component to match expected parameter formatting.

- Remove an extra blank character left after a conditional block.
- Add a missing trailing comma for the plugin argument in the
  ToggleSetting constructor call to ensure consistent argument
  separation and avoid potential lint/format issues.

These small fixes improve code style consistency and prevent minor
syntax/formatting problems in the UI linter component.